### PR TITLE
Depend on fixed version for reproducible build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+target

--- a/pom.xml
+++ b/pom.xml
@@ -38,18 +38,19 @@ questions.
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>RELEASE</version>
+            <version>${jmh.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>RELEASE</version>
+            <version>${jmh.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>0.7.3</jmh.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Post 0.7.3 version of JMH, GenerateMicroBenchmark and BlackHole where deprecated/Renamed/removed/you-name-it.
